### PR TITLE
Fix two typos in multi-tenant readme

### DIFF
--- a/multi-tenant/README.md
+++ b/multi-tenant/README.md
@@ -29,6 +29,6 @@ $ docker compose up
 If you have compiled a development distribution of Opencast on your host machine (using `-Pdev`), you can run this compiled version with the `docker-compose.dev.yaml` variation. Use the following commands to point to the Opencast source folder and start up the containers:
 
 ```sh
-$ expose OPENCAST_SRC="/path/to/my/opencast/src/root/folder"
-$ docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up
+$ export OPENCAST_SRC="/path/to/my/opencast/src/root/folder"
+$ docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up
 ```


### PR DESCRIPTION
Very convenient script by the way, thanks for that!