### PR TITLE
Update Opencast-Moodle to v5

### DIFF
--- a/lms/README.md
+++ b/lms/README.md
@@ -27,5 +27,5 @@ $ docker compose -f compose.yaml -f compose.moodle.yaml exec -- moodle php admin
 Alternatively, you may also run specific tasks, e.g. `process_upload_cron`:
 
 ```sh
-$ docker compose -f compose.yaml -f compose.moodle.yaml exec -- moodle php admin/cli/scheduled_task.php '--execute=\block_opencast\task\process_upload_cron'
+$ docker compose -f compose.yaml -f compose.moodle.yaml exec -- moodle php admin/cli/scheduled_task.php '--execute=\tool_opencast\task\process_upload_cron'
 ```

--- a/lms/compose.moodle.yaml
+++ b/lms/compose.moodle.yaml
@@ -17,12 +17,12 @@ services:
       args:
         MOODLE_PHP_APACHE: "8.4"
         MOODLE_VERSION: "v5.0.1"
-        MOODLE_LOCAL_CHUNKUPLOAD: "upgrade-500"
-        MOODLE_REPOSITORY_OPENCAST: "upgrade-500"
-        MOODLE_FILTER_OPENCAST: "upgrade-500"
-        MOODLE_TOOL_OPENCAST: "upgrade-500"
-        MOODLE_MOD_OPENCAST: "upgrade-500"
-        MOODLE_BLOCK_OPENCAST: "upgrade-500"
+        MOODLE_LOCAL_CHUNKUPLOAD: "v5.0-r1"
+        MOODLE_REPOSITORY_OPENCAST: "v5.0-r1"
+        MOODLE_FILTER_OPENCAST: "v5.0-r1"
+        MOODLE_TOOL_OPENCAST: "v5.0-r1"
+        MOODLE_MOD_OPENCAST: "v5.0-r1"
+        MOODLE_BLOCK_OPENCAST: "v5.0-r1"
     restart: on-failure
     environment:
       WWWROOT: http://moodle.localtest.me

--- a/lms/compose.moodle.yaml
+++ b/lms/compose.moodle.yaml
@@ -15,8 +15,8 @@ services:
     build:
       context: ./services/moodle
       args:
-        MOODLE_PHP_APACHE: "8.3"
-        MOODLE_VERSION: "v4.5.1"
+        MOODLE_PHP_APACHE: "8.4"
+        MOODLE_VERSION: "v5.0.1"
         MOODLE_LOCAL_CHUNKUPLOAD: "v4.5-r3"
         MOODLE_REPOSITORY_OPENCAST: "v4.5-r3"
         MOODLE_FILTER_OPENCAST: "v4.5-r3"

--- a/lms/compose.moodle.yaml
+++ b/lms/compose.moodle.yaml
@@ -17,12 +17,12 @@ services:
       args:
         MOODLE_PHP_APACHE: "8.4"
         MOODLE_VERSION: "v5.0.1"
-        MOODLE_LOCAL_CHUNKUPLOAD: "v4.5-r3"
-        MOODLE_REPOSITORY_OPENCAST: "v4.5-r3"
-        MOODLE_FILTER_OPENCAST: "v4.5-r3"
-        MOODLE_TOOL_OPENCAST: "v4.5-r3"
-        MOODLE_MOD_OPENCAST: "v4.5-r3"
-        MOODLE_BLOCK_OPENCAST: "v4.5-r3"
+        MOODLE_LOCAL_CHUNKUPLOAD: "upgrade-500"
+        MOODLE_REPOSITORY_OPENCAST: "upgrade-500"
+        MOODLE_FILTER_OPENCAST: "upgrade-500"
+        MOODLE_TOOL_OPENCAST: "upgrade-500"
+        MOODLE_MOD_OPENCAST: "upgrade-500"
+        MOODLE_BLOCK_OPENCAST: "upgrade-500"
     restart: on-failure
     environment:
       WWWROOT: http://moodle.localtest.me

--- a/lms/compose.moodle.yaml
+++ b/lms/compose.moodle.yaml
@@ -3,7 +3,7 @@ volumes:
 
 services:
   moodle-db:
-    image: postgres:16-alpine
+    image: docker.io/library/postgres:16-alpine
     environment:
       POSTGRES_USER: moodle
       POSTGRES_PASSWORD: moodle

--- a/lms/compose.yaml
+++ b/lms/compose.yaml
@@ -22,7 +22,7 @@ services:
           - moodle.localtest.me
 
   opencast:
-    image: quay.io/opencast/allinone:17.4
+    image: quay.io/opencast/allinone:18
     hostname: opencast
     healthcheck:
       disable: true

--- a/lms/compose.yaml
+++ b/lms/compose.yaml
@@ -22,7 +22,7 @@ services:
           - moodle.localtest.me
 
   opencast:
-    image: quay.io/opencast/allinone:17.0
+    image: quay.io/opencast/allinone:17.4
     hostname: opencast
     healthcheck:
       disable: true

--- a/lms/compose.yaml
+++ b/lms/compose.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   nginx:
-    image: nginx:1.27-alpine
+    image: docker.io/library/nginx:1.27-alpine
     restart: on-failure
     ports:
       - "80:80"

--- a/lms/services/moodle/Dockerfile
+++ b/lms/services/moodle/Dockerfile
@@ -1,5 +1,5 @@
 ARG MOODLE_PHP_APACHE=latest
-FROM moodlehq/moodle-php-apache:$MOODLE_PHP_APACHE
+FROM docker.io/moodlehq/moodle-php-apache:$MOODLE_PHP_APACHE
 
 USER www-data
 

--- a/lms/services/moodle/Dockerfile
+++ b/lms/services/moodle/Dockerfile
@@ -50,4 +50,4 @@ COPY rootfs /
 RUN docker-php-ext-enable xdebug \
  && sed -i 's/^; zend_extension=/zend_extension=/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/entrypoint.sh"]

--- a/lms/services/moodle/rootfs/var/www/html/admin/cli/init_plugin_configs.php
+++ b/lms/services/moodle/rootfs/var/www/html/admin/cli/init_plugin_configs.php
@@ -6,118 +6,164 @@ require(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/moodlelib.php');
 
+$plugin_configs = array(
+  'tool_opencast' => array(
+    // Opencast Instances
+    'ocinstances'   => '[{"id": 1, "name":"Default",  "isvisible": 1, "isdefault": 1}]',
+    'apiurl_1'      => 'http://opencast.localtest.me',
+    'apiusername_1' => 'moodle',
+    'apipassword_1' => 'moodle',
 
-cli_writeln('Settings for tool_opencast');
+    // Maintenance
+    'maintenancemode_1' => 'Disable',
 
-set_config('ocinstances',   '[{"id": 1, "name":"Default",  "isvisible": 1, "isdefault": 1}]', 'tool_opencast');
-set_config('apiurl_1',      'http://opencast.localtest.me',                                   'tool_opencast');
-set_config('apiusername_1', 'moodle',                                                         'tool_opencast');
-set_config('apipassword_1', 'moodle',                                                         'tool_opencast');
+    // General settings
+    'limituploadjobs_1'      => 10,
+    'uploadworkflow_1'       => 'schedule-and-upload',
+    'publishtoengage_1'      => 1,
+    'deleteworkflow_1'       => 'delete',
+    'uploadfileextensions_1' => '.aac,.aiff,.flac,.m4a,.mp3,.oga,.ogg,.wav,video,.3gp,.f4v,.flv,.fmp4,.m4v,.mov,.mp4,.mpeg,.mpg,.ogv,.qt,.ts,.webm',
 
+    // Group and Series
+    'series_name_1' => '[COURSENAME]',
 
+    // Roles
+    'workflow_roles_1' => 'republish-metadata',
+    'roles_1'          => '[{ "rolename":  "ROLE_ADMIN",
+                              "actions":   "read,write",
+                              "permanent": 1 },
+                            { "rolename":  "ROLE_GROUP_MOODLE",
+                              "actions":   "read,write",
+                              "permanent": 1 },
+                            { "rolename":  "ROLE_OWNER_[USERNAME]",
+                              "actions":   "read,write",
+                              "permanent": 1 },
+                            { "rolename":  "ROLE_USER_[USERNAME]",
+                              "actions":   "read,write",
+                              "permanent": 1 }]',
+    'aclownerrole_1'   => 'ROLE_OWNER_[USERNAME]',
 
-cli_writeln('Settings for mod_opencast');
+    // Event Metadata
 
-set_config('channel_1',          'engage-player', 'mod_opencast');
-set_config('download_channel_1', 'engage-player', 'mod_opencast');
-set_config('download_default_1', 1,               'mod_opencast');
+    // Series Metadata
 
+    // Appearance
+    // Overview page
+    'showpublicationchannels_1' => 0,
 
+    // Additional features
+    // Settings for the chunkuploader
+    'uploadfilelimit_1'             => 5368709120, # 5GB
+    'offerchunkuploadalternative_1' => 0,
 
-cli_writeln('Settings for block_opencast');
+    // Opencast studio integration
+    'enable_opencast_studio_link_1'     => 1,
+    'opencast_studio_baseurl_1'         => 'http://opencast.localtest.me',
+    'show_opencast_studio_return_btn_1' => 1,
 
-set_config('limituploadjobs_1',                  10,                                 'block_opencast');
-set_config('uploadworkflow_1',                   'schedule-and-upload',              'block_opencast');
-set_config('publishtoengage_1',                  1,                                  'block_opencast');
-set_config('ingestupload_1',                     0,                                  'block_opencast');
-set_config('deleteworkflow_1',                   'delete',                           'block_opencast');
-set_config('uploadfileextensions_1',             '.aac,.aiff,.flac,.m4a,.mp3,.oga,.ogg,.wav,video,.3gp,.f4v,.flv,.fmp4,.m4v,.mov,.mp4,.mpeg,.mpg,.ogv,.qt,.ts,.webm', 'block_opencast');
-set_config('batchuploadenabled_1',               1,                                  'block_opencast');
-set_config('group_creation_1',                   0,                                  'block_opencast');
-set_config('series_name_1',                      '[COURSENAME]',                     'block_opencast');
-set_config('workflow_roles_1',                   'republish-metadata',               'block_opencast');
-set_config('roles_1',                            '[{ "rolename":  "ROLE_ADMIN",
-                                                     "actions":   "read,write",
-                                                     "permanent": 1 },
-                                                   { "rolename":  "ROLE_GROUP_MOODLE",
-                                                     "actions":   "read,write",
-                                                     "permanent": 1 },
-                                                   { "rolename":  "ROLE_OWNER_[USERNAME]",
-                                                     "actions":   "read,write",
-                                                     "permanent": 1 },
-                                                   { "rolename":  "ROLE_USER_[USERNAME]",
-                                                     "actions":   "read,write",
-                                                     "permanent": 1 }]',             'block_opencast');
-set_config('aclownerrole_1',                     'ROLE_OWNER_[USERNAME]',            'block_opencast');
-set_config('showpublicationchannels_1',          0,                                  'block_opencast');
-set_config('showenddate_1',                      1,                                  'block_opencast');
-set_config('showlocation_1',                     1,                                  'block_opencast');
-set_config('enablechunkupload_1',                1,                                  'block_opencast');
-set_config('uploadfilelimit_1',                  5368709120,                         'block_opencast');
-set_config('offerchunkuploadalternative_1',      0,                                  'block_opencast');
-set_config('enable_opencast_studio_link_1',      1,                                  'block_opencast');
-set_config('open_studio_in_new_tab_1',           1,                                  'block_opencast');
-set_config('opencast_studio_baseurl_1',          'http://opencast.localtest.me',     'block_opencast');
-set_config('show_opencast_studio_return_btn_1',  1,                                  'block_opencast');
-set_config('enable_opencast_editor_link_1',      1,                                  'block_opencast');
-set_config('editorbaseurl_1',                    'http://opencast.localtest.me',     'block_opencast');
-set_config('editorendpointurl_1',                '/editor-ui/index.html?id=',        'block_opencast');
-set_config('eventstatusnotificationenabled_1',   1,                                  'block_opencast');
-set_config('eventstatusnotificationdeletion_1',  2,                                  'block_opencast');
-set_config('aclcontrol_1',                       0,                                  'block_opencast');
-set_config('aclcontrolafter_1',                  0,                                  'block_opencast');
-set_config('aclcontrolgroup_1',                  0,                                  'block_opencast');
-set_config('addactivityenabled_1',               1,                                  'block_opencast');
-set_config('addactivityintro_1',                 1,                                  'block_opencast');
-set_config('addactivitysection_1',               1,                                  'block_opencast');
-set_config('addactivityavailability_1',          1,                                  'block_opencast');
-set_config('addactivityepisodeenabled_1',        1,                                  'block_opencast');
-set_config('addactivityepisodeintro_1',          1,                                  'block_opencast');
-set_config('addactivityepisodesection_1',        1,                                  'block_opencast');
-set_config('addactivityepisodeavailability_1',   1,                                  'block_opencast');
-# TODO: Transcriptions
-set_config('liveupdateenabled_1',                1,                                  'block_opencast');
-set_config('download_channel_1',                 'engage-player',                    'block_opencast');
-# TODO: direct_access_channel_1?
-set_config('workflow_tag_1',                     'archive',                          'block_opencast');
-set_config('support_email_1',                    'admin@moodle.localtest.me',        'block_opencast');
-set_config('termsofuse_1',                       '<p><strong>Be Nice!</strong></p>', 'block_opencast');
-set_config('addltienabled_1',                    0,                                  'block_opencast');
-set_config('addltiepisodeenabled_1',             0,                                  'block_opencast');
-set_config('importvideosenabled_1',              1,                                  'block_opencast');
-set_config('importmode_1',                       'acl',                              'block_opencast');
-set_config('importvideoscoreenabled_1',          1,                                  'block_opencast');
-set_config('importvideoscoredefaultvalue_1',     'Checked',                          'block_opencast');
-set_config('importvideosmanualenabled_1',        1,                                  'block_opencast');
-set_config('importvideoshandleseriesenabled_1',  0,                                  'block_opencast');
-set_config('importvideoshandleepisodeenabled_1', 0,                                  'block_opencast');
+    // Opencast Editor integration
+    'enable_opencast_editor_link_1' => 1,
+    'editorbaseurl_1'               => 'http://opencast.localtest.me',
+    'editorendpointurl_1'           => '/editor-ui/index.html?id=',
 
+    // Engage player integration
+    'engageurl_1' => 'http://opencast.localtest.me',
 
+    // Notifications
+    'eventstatusnotificationenabled_1'  => 1,
+    'eventstatusnotificationdeletion_1' => 2,
+
+    // Control episode visibility
+    'aclcontrol_1'      => 0,
+    'aclcontrolafter_1' => 0,
+    'aclcontrolgroup_1' => 0,
+
+    // Add Opencast Activity modules to courses
+    'addactivityenabled_1'      => 1,
+    'addactivityintro_1'        => 1,
+    'addactivitysection_1'      => 1,
+    'addactivityavailability_1' => 1,
+
+    'addactivityepisodeenabled_1'      => 1,
+    'addactivityepisodeintro_1'        => 1,
+    'addactivityepisodesection_1'      => 1,
+    'addactivityepisodeavailability_1' => 1,
+
+    // Settings for Transcription
+
+    // Live Status Update
+    'liveupdatereloadtimeout_1' => 10,
+
+    // Workflows Privacy Notice
+
+    // Additional features
+    'download_channel_1' => 'engage-player',
+    'workflow_tags_1'    => 'archive',
+    'support_email_1'    => 'admin@moodle.localtest.me',
+    'termsofuse_1'       => '<p><strong>Be Nice!</strong></p>',
+
+    // LTI module features
+    // Add Opencast LTI series modules to courses
+    'addltienabled_1' => 0,
+
+    // Add Opencast LTI episode modules to courses
+    'addltiepisodeenabled_1' => 0,
+
+    // Import videos features
+    // Import videos from other courses
+    'importmode_1'                => 'acl',
+    'duplicateworkflow_1'         => 'duplicate-event',
+    'importvideosmanualenabled_1' => 1,
+
+    // Shared settings
+    'uploadtimeout'          => 500,
+    'faileduploadretrylimit' => 5,
+  ),
+
+  'mod_opencast' => array(
+    'channel_1'          => 'engage-player',
+    'download_channel_1' => 'engage-player',
+    'download_default_1' => 1,
+  ),
+
+  'block_opencast' => array(
+    'limitvideos_1' => 5,
+  ),
+
+  'filter_opencast' => array(
+    'episodeurl_1' => 'http://opencast.localtest.me/play/[EPISODEID]',
+  ),
+);
+
+foreach ($plugin_configs as $plugin => $configs) {
+  cli_writeln('');
+  cli_writeln('Settings for '.$plugin);
+
+  foreach ($configs as $key => $value) {
+    cli_writeln('   '.$key.' = '.$value);
+    set_config($key, $value, $plugin);
+  }
+}
+
+filter_set_global_state('opencast', 1);
 
 cli_writeln('Settings for repository_opencast');
 
 $repository = new stdClass();
 $repository->edit = 0;
-$repository->new = "opencast";
-$repository->plugin = "opencast";
+$repository->new = 'opencast';
+$repository->plugin = 'opencast';
 $repository->typeid = 0;
 $repository->contextid = 1;
-$repository->name = "Opencast videos";
+$repository->name = 'Opencast videos';
 $repository->opencast_instance = 1;
-$repository->opencast_author = "";
-$repository->opencast_channelid = "engage-player";
-$repository->opencast_thumbnailflavor = "";
-$repository->opencast_thumbnailflavorfallback = "";
+$repository->opencast_author = '';
+$repository->opencast_channelid = 'engage-player';
+$repository->opencast_thumbnailflavor = '';
+$repository->opencast_thumbnailflavorfallback = '';
 $repository->opencast_playerurl = 1;
-$repository->opencast_videoflavor = "";
-$repository->submitbutton = "Save";
+$repository->opencast_videoflavor = '';
+$repository->submitbutton = 'Save';
 repository::create('opencast', 0, context_system::instance(), $repository);
-
-
-
-cli_writeln('Settings for filter_opencast');
-
-filter_set_global_state("opencast", 1);
-set_config('episodeurl_1', 'http://opencast.localtest.me/play/[EPISODEID]', 'filter_opencast');
 
 exit(0);


### PR DESCRIPTION
This is updating the Opencast-Moodle example to v5. Currently, there is only the branch `upgrade-500` available. Once v5 tags are available, I will update this PR. Do not merge until then.